### PR TITLE
don't run html escape on script contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -378,6 +378,9 @@ Text.prototype.nodeType = 3;
 Text.prototype.nodeName = '#text';
 
 Text.prototype.__defineGetter__('textContent', function() {
+  if (this.parentElement?.nodeName?.toLowerCase() === 'script') {
+    return this.value || '';
+  }
   return escapeHTML(this.value || '');
 });
 


### PR DESCRIPTION
A script may contain HTML inside of it such as:

```
{
  "html": "<b>Hello</b>"
}
```

Before this commit, this would appear as:

```
{
  "html": "&lt;b&gt;Hello&lt;/b&gt;"
}
```